### PR TITLE
fix(fonts): use bundled font URLs instead of /src paths

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -6,6 +6,7 @@ import type { ImageMetadata } from "astro";
 import FallbackImage from "../assets/og.webp";
 import { SITE_TITLE } from "../consts";
 import { Font } from "astro:assets";
+import materialSymbolsFont from "../assets/fonts/material-symbols-outlined.woff2";
 
 interface Props {
   title: string;
@@ -37,7 +38,7 @@ const { title, description, image = FallbackImage } = Astro.props;
 <!-- Preload Material Symbols font for faster rendering -->
 <link
   rel="preload"
-  href="/src/assets/fonts/material-symbols-outlined.woff2"
+  href={materialSymbolsFont}
   as="font"
   type="font/woff2"
   crossorigin
@@ -104,12 +105,3 @@ const { title, description, image = FallbackImage } = Astro.props;
     "priceRange": "$$"
   }
 </script>
-
-<style>
-  :root {
-    /* `--font-atkinson` is provided by Astro's font provider (astro.config.mjs)
-       Map design tokens to that variable so components can use them. */
-    --font-body: var(--font-atkinson);
-    --font-headline: var(--font-atkinson);
-  }
-</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,27 +58,12 @@
   background: linear-gradient(135deg, #003358 0%, #004a7c 100%);
 }
 
-/* Font faces with optimized loading */
-@font-face {
-  font-family: "Atkinson";
-  src: url("/src/assets/fonts/atkinson-regular.woff") format("woff");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "Atkinson";
-  src: url("/src/assets/fonts/atkinson-bold.woff") format("woff");
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-
 @theme {
-  --font-headline: "Atkinson", sans-serif;
-  --font-body: "Atkinson", sans-serif;
-  --font-label: "Atkinson", sans-serif;
+  /* Atkinson is provided by Astro's local font provider (astro.config.mjs)
+     and exposed through the --font-atkinson CSS variable. */
+  --font-headline: var(--font-atkinson), sans-serif;
+  --font-body: var(--font-atkinson), sans-serif;
+  --font-label: var(--font-atkinson), sans-serif;
   --color-on-error: #ffffff;
   --color-on-tertiary-fixed: #00210f;
   --color-surface-container: #eceef0;


### PR DESCRIPTION
In production the /src/... paths don't exist (assets are hashed into /_astro), so the Material Symbols preload 404'd. Fix the prod font setup:

- preload the Material Symbols woff2 via an imported asset, so the href resolves to the hashed /_astro URL (matching the @font-face)
- drop the duplicate manual Atkinson @font-face (broken /src URLs) and point --font-headline/body/label at Astro's --font-atkinson, so the font provider is the single source of truth (also fixes the "preloaded but not used" warnings)