### PR TITLE
fix(fonts): stop preloading fonts to silence "preloaded but not used"

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -6,7 +6,6 @@ import type { ImageMetadata } from "astro";
 import FallbackImage from "../assets/og.webp";
 import { SITE_TITLE } from "../consts";
 import { Font } from "astro:assets";
-import materialSymbolsFont from "../assets/fonts/material-symbols-outlined.woff2";
 
 interface Props {
   title: string;
@@ -33,16 +32,7 @@ const { title, description, image = FallbackImage } = Astro.props;
 />
 <meta name="generator" content={Astro.generator} />
 
-<Font cssVariable="--font-atkinson" preload />
-
-<!-- Preload Material Symbols font for faster rendering -->
-<link
-  rel="preload"
-  href={materialSymbolsFont}
-  as="font"
-  type="font/woff2"
-  crossorigin
-/>
+<Font cssVariable="--font-atkinson" />
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,7 +5,9 @@
   font-family: "Material Symbols Outlined";
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  /* `block` avoids briefly flashing the ligature text (e.g. "arrow_forward")
+     before the icon font loads, now that it is no longer preloaded. */
+  font-display: block;
   src: url("../assets/fonts/material-symbols-outlined.woff2") format("woff2");
 }
 


### PR DESCRIPTION
The font preloads were correct (hrefs matched the @font-face src), but Firefox still logs "preloaded but not used within a few seconds" for each one. Drop the preloads (Astro <Font> preload + the Material Symbols link); fonts still load via their @font-face. Switch the icon font to font-display: block so icons don't briefly flash their ligature text now that it isn't preloaded.